### PR TITLE
additional packages needed, installation notes on psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ brew install postgresql
 See https://github.com/psycopg/psycopg2/issues/1200
 
 
-2. Turn your PDF into embeddings for GPT-3:
+3. Turn your PDF into embeddings for GPT-3:
 
 ```
 python scripts/pdf_to_pages_embeddings.py --pdf book.pdf
 ```
 
-3. Set up database tables:
+4. Set up database tables:
 
 ```
 python manage.py makemigrations
 python manage.py migrate
 ```
 
-4. Other things to update:
+5. Other things to update:
 
 - Book title
 - Book cover image

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 1. Create and fill in `.env` using `.env.example` as an example.
 
+2. Install required Python packages
+
+```
+pip install -r requirements.txt
+```
+
+Mac M1 / OS X Note: if you get an error installing psycopg2, you may need:
+
+```
+brew install postgresql
+```
+
+See https://github.com/psycopg/psycopg2/issues/1200
+
+
 2. Turn your PDF into embeddings for GPT-3:
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ numpy>=1.23.4
 pandas>=1.5.0
 openai>=0.25.0
 resemble>=1.3.0
+python-dotenv>=0.21.0
+transformers>=4.25.1
+pypdf2>=3.0.1


### PR DESCRIPTION
When setting up to run the PDF conversion on my machine (Macbook Pro M1), I ran into a couple of issues:

1) psycopg2 failing to build
2) After installing the requirements.txt packages, I was still missing transformers, pypdf2, and python-dotenv in my virtual environment

Added some notes to the README and the requirements.txt that worked for me.