### PR TITLE
Update the generated CSV filenames to a fixed name instead of based on the original title

### DIFF
--- a/scripts/pdf_to_pages_embeddings.py
+++ b/scripts/pdf_to_pages_embeddings.py
@@ -71,7 +71,7 @@ df = df[df.tokens<2046]
 df = df.reset_index().drop('index',axis=1) # reset index
 df.head()
 
-df.to_csv(f'{filename}.pages.csv', index=False)
+df.to_csv(f'book.pdf.pages.csv', index=False)
 
 def get_embedding(text: str, model: str) -> list[float]:
     result = openai.Embedding.create(
@@ -98,7 +98,7 @@ def compute_doc_embeddings(df: pd.DataFrame) -> dict[tuple[str], list[float]]:
 
 doc_embeddings = compute_doc_embeddings(df)
 
-with open(f'{filename}.embeddings.csv', 'w') as f:
+with open(f'book.pdf.embeddings.csv', 'w') as f:
     writer = csv.writer(f)
     writer.writerow(["title"] + list(range(4096)))
     for i, embedding in list(doc_embeddings.items()):


### PR DESCRIPTION
## Description

Currently, the filename generated is based on the original pdf file passed to the script.
Now, it will use `book.pdf` as prefix to `pages.csv` and `embeddings.csv` files.

## Why
When reading those files, [fixed filenames](https://github.com/slavingia/askmybook/blob/main/hello/views.py#L167-L168) are being used, thus the current version only works when the pdf file used to generate the embeddings is `book.pdf`. With this change, as we'll be always adoption `book.pdf` as filename prefix, it should be reachable by the `views` file independent of the original PDF filename.

Usage reference: https://github.com/slavingia/askmybook/blob/main/hello/views.py#L167-L168 
